### PR TITLE
updated TabBarController to behave with Swift 1.2,

### DIFF
--- a/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
+++ b/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
@@ -75,7 +75,7 @@ class RAMAnimatedTabBarController: UITabBarController {
 
                 assert(item.image != nil, "add image icon in UITabBarItem")
 
-                var container : UIView = containers["container\(itemsCount-index)"] as UIView
+                var container : UIView = containers["container\(itemsCount-index)"] as! UIView
                 container.tag = index
 
                 var icon = UIImageView(image: item.image)
@@ -215,7 +215,7 @@ class RAMAnimatedTabBarController: UITabBarController {
 
     func tapHandler(gesture:UIGestureRecognizer) {
 
-        let items = tabBar.items as [RAMAnimatedTabBarItem]
+        let items = tabBar.items as! [RAMAnimatedTabBarItem]
 
         let currentIndex = gesture.view!.tag
         if selectedIndex != currentIndex {


### PR DESCRIPTION
 forced conversion now uses the 'as!' operator instead of 'as' without the exclamation mark.  Updated behavior discussed here: https://developer.apple.com/swift/blog/