### PR TITLE
change selectedState of FumeAnimation

### DIFF
--- a/RAMAnimatedTabBarController/Animations/FumeAnimation/RAMFumeAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/FumeAnimation/RAMFumeAnimation.swift
@@ -52,7 +52,7 @@ class RAMFumeAnimation : RAMItemAnimation {
 
     override func selectedState(icon : UIImageView, textLabel : UILabel) {
 
-        playMoveIconAnimation(icon, values:[icon.center.y + 8.0])
+        playMoveIconAnimation(icon, values:[icon.center.y + 12.0])
         textLabel.alpha = 0
         textLabel.textColor = textSelectedColor
       


### PR DESCRIPTION
if you set the FumeAnimation as the first selected tabbarItem, you will
see the item is too high. So I change 8.0 to 12.0. My English is poor,
I hope you can understand my meaning.