### PR TITLE
add @nonobjc attribute to animationImages in RAMFrameItemAnimation

### DIFF
--- a/RAMAnimatedTabBarController/Animations/FrameAnimation/RAMFrameItemAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/FrameAnimation/RAMFrameItemAnimation.swift
@@ -25,7 +25,7 @@ import QuartzCore
 
 public class RAMFrameItemAnimation: RAMItemAnimation {
 
-    public var animationImages : Array<CGImage> = Array()
+    @nonobjc public var animationImages : Array<CGImage> = Array()
 
     public var selectedImage : UIImage!
 

--- a/RAMAnimatedTabBarController/Animations/FrameAnimation/RAMFrameItemAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/FrameAnimation/RAMFrameItemAnimation.swift
@@ -80,7 +80,7 @@ public class RAMFrameItemAnimation: RAMItemAnimation {
         textLabel.textColor = textSelectedColor
     }
 
-    func playFrameAnimation(icon : UIImageView, images : Array<CGImage>) {
+    @nonobjc func playFrameAnimation(icon : UIImageView, images : Array<CGImage>) {
         let frameAnimation = CAKeyframeAnimation(keyPath: Constants.AnimationKeys.KeyFrame)
         frameAnimation.calculationMode = kCAAnimationDiscrete
         frameAnimation.duration = NSTimeInterval(duration)


### PR DESCRIPTION
the `animationImages : Array<CGImage>` var on `RAMFrameItemAnimation` can cause the compiler to throw a fit in certain scenarios, 
```
<module-includes>:2:9: note: in file included from <module-includes>:2:
#import "Headers/RAMAnimatedTabBarController-Swift.h"
        ^
.../Build/Products/Debug-iphonesimulator/RAMAnimatedTabBarController.framework/Headers/RAMAnimatedTabBarController-Swift.h:158:37: error: type argument 'CGImageRef' (aka 'struct CGImage *') is neither an Objective-C object nor a block type
@property (nonatomic, copy) NSArray<CGImageRef> * __nonnull animationImages;
                                    ^
<unknown>:0: error: could not build Objective-C module 'RAMAnimatedTabBarController'
```

This appears to have been discussed previously https://github.com/Ramotion/animated-tab-bar/issues/49 but the `nonobjc` attributes are still absent from the source. 