### PR TITLE
Make RAMItemAnimation methods public

### DIFF
--- a/RAMAnimatedTabBarController/Animations/BounceAnimation/RAMBounceAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/BounceAnimation/RAMBounceAnimation.swift
@@ -25,12 +25,12 @@ import UIKit
 
 public class RAMBounceAnimation : RAMItemAnimation {
 
-    override func playAnimation(icon : UIImageView, textLabel : UILabel) {
+    override public func playAnimation(icon : UIImageView, textLabel : UILabel) {
         playBounceAnimation(icon)
         textLabel.textColor = textSelectedColor
     }
 
-    override func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor: UIColor) {
+    override public func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor: UIColor) {
         textLabel.textColor = defaultTextColor
       
         if let iconImage = icon.image {
@@ -42,7 +42,7 @@ public class RAMBounceAnimation : RAMItemAnimation {
         }
     }
 
-    override func selectedState(icon : UIImageView, textLabel : UILabel) {
+    override public func selectedState(icon : UIImageView, textLabel : UILabel) {
         textLabel.textColor = textSelectedColor
       
         if let iconImage = icon.image {

--- a/RAMAnimatedTabBarController/Animations/FrameAnimation/RAMFrameItemAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/FrameAnimation/RAMFrameItemAnimation.swift
@@ -61,13 +61,13 @@ public class RAMFrameItemAnimation: RAMItemAnimation {
         }
     }
 
-    override func playAnimation(icon : UIImageView, textLabel : UILabel) {
+    override public func playAnimation(icon : UIImageView, textLabel : UILabel) {
 
         playFrameAnimation(icon, images:animationImages)
         textLabel.textColor = textSelectedColor
     }
 
-    override func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
+    override public func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
         if isDeselectAnimation {
             playFrameAnimation(icon, images:animationImages.reverse())
         }
@@ -75,7 +75,7 @@ public class RAMFrameItemAnimation: RAMItemAnimation {
         textLabel.textColor = defaultTextColor
     }
 
-    override func selectedState(icon : UIImageView, textLabel : UILabel) {
+    override public func selectedState(icon : UIImageView, textLabel : UILabel) {
         icon.image = selectedImage
         textLabel.textColor = textSelectedColor
     }

--- a/RAMAnimatedTabBarController/Animations/FumeAnimation/RAMFumeAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/FumeAnimation/RAMFumeAnimation.swift
@@ -26,7 +26,7 @@ import UIKit
 
 public class RAMFumeAnimation : RAMItemAnimation {
 
-    override func playAnimation(icon : UIImageView, textLabel : UILabel) {
+    override public func playAnimation(icon : UIImageView, textLabel : UILabel) {
         playMoveIconAnimation(icon, values:[icon.center.y, icon.center.y + 4.0])
         playLabelAnimation(textLabel)
         textLabel.textColor = textSelectedColor
@@ -38,7 +38,7 @@ public class RAMFumeAnimation : RAMItemAnimation {
         }
     }
 
-    override func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
+    override public func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
         
         playMoveIconAnimation(icon, values:[icon.center.y + 4.0, icon.center.y])
         playDeselectLabelAnimation(textLabel)
@@ -53,7 +53,7 @@ public class RAMFumeAnimation : RAMItemAnimation {
         }
     }
 
-    override func selectedState(icon : UIImageView, textLabel : UILabel) {
+    override public func selectedState(icon : UIImageView, textLabel : UILabel) {
 
         playMoveIconAnimation(icon, values:[icon.center.y + 12.0])
         textLabel.alpha = 0

--- a/RAMAnimatedTabBarController/Animations/RotationAnimation/RAMRotationAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/RotationAnimation/RAMRotationAnimation.swift
@@ -32,12 +32,12 @@ public class RAMRotationAnimation : RAMItemAnimation {
 
     public var direction : RAMRotationDirection!
 
-    override func playAnimation(icon : UIImageView, textLabel : UILabel) {
+    override public func playAnimation(icon : UIImageView, textLabel : UILabel) {
         playRoatationAnimation(icon)
         textLabel.textColor = textSelectedColor
     }
 
-    override func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
+    override public func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
         textLabel.textColor = defaultTextColor
       
         if let iconImage = icon.image {
@@ -49,7 +49,7 @@ public class RAMRotationAnimation : RAMItemAnimation {
         }
     }
 
-    override func selectedState(icon : UIImageView, textLabel : UILabel) {
+    override public func selectedState(icon : UIImageView, textLabel : UILabel) {
         textLabel.textColor = textSelectedColor
       
         if let iconImage = icon.image {

--- a/RAMAnimatedTabBarController/Animations/TransitionAniamtions/RAMTransitionItemAnimations.swift
+++ b/RAMAnimatedTabBarController/Animations/TransitionAniamtions/RAMTransitionItemAnimations.swift
@@ -32,7 +32,7 @@ public class RAMTransitionItemAnimations : RAMItemAnimation {
         transitionOptions = UIViewAnimationOptions.TransitionNone
     }
 
-    override func playAnimation(icon : UIImageView, textLabel : UILabel) {
+    override public func playAnimation(icon : UIImageView, textLabel : UILabel) {
 
         selectedColor(icon, textLabel: textLabel)
 
@@ -41,7 +41,7 @@ public class RAMTransitionItemAnimations : RAMItemAnimation {
         })
     }
 
-    override func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
+    override public func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
 
         if let iconImage = icon.image {
             let renderMode = CGColorGetAlpha(defaultIconColor.CGColor) == 0 ? UIImageRenderingMode.AlwaysOriginal :
@@ -53,7 +53,7 @@ public class RAMTransitionItemAnimations : RAMItemAnimation {
         textLabel.textColor = defaultTextColor
     }
 
-    override func selectedState(icon : UIImageView, textLabel : UILabel) {
+    override public func selectedState(icon : UIImageView, textLabel : UILabel) {
 
         selectedColor(icon, textLabel: textLabel)
     }

--- a/RAMAnimatedTabBarController/RAMItemAnimationProtocol.swift
+++ b/RAMAnimatedTabBarController/RAMItemAnimationProtocol.swift
@@ -35,7 +35,7 @@ public class RAMItemAnimation: NSObject, RAMItemAnimationProtocol {
 
     // MARK: constants
     
-    struct Constants {
+    public struct Constants {
         
         struct AnimationKeys {
             
@@ -54,12 +54,12 @@ public class RAMItemAnimation: NSObject, RAMItemAnimationProtocol {
     @IBInspectable public var textSelectedColor: UIColor = UIColor.init(red: 0, green: 0.478431, blue: 1, alpha: 1)
     @IBInspectable public var iconSelectedColor: UIColor!
 
-    func playAnimation(icon : UIImageView, textLabel : UILabel) {
+    public func playAnimation(icon : UIImageView, textLabel : UILabel) {
     }
 
-    func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
+    public func deselectAnimation(icon : UIImageView, textLabel : UILabel, defaultTextColor : UIColor, defaultIconColor : UIColor) {
     }
 
-    func selectedState(icon: UIImageView, textLabel : UILabel) {
+    public func selectedState(icon: UIImageView, textLabel : UILabel) {
     }
 }


### PR DESCRIPTION
In order to create a custom `RAMItemAnimation` subclass as shown in the readme examples, the animation functions need to be public so that they can be overridden by a sublcass in a different package.

The `RAM` sublcasses of `RAMItemAnimation` also have to make this change to please swifts overriding rules with regards to method visibility. 