### PR TITLE
Fix small bug in delegate

### DIFF
--- a/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
+++ b/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
@@ -348,7 +348,7 @@ public class RAMAnimatedTabBarController: UITabBarController {
             container.backgroundColor = items[currentIndex].bgSelectedColor
 
             selectedIndex = gestureView.tag
-            delegate?.tabBarController?(self, didSelectViewController: self)
+            delegate?.tabBarController?(self, didSelectViewController: controller)
 
         } else if selectedIndex == currentIndex {
 


### PR DESCRIPTION
Fix small bug in delegate that call UITabBarViewControllerDelegate with wrong parameter. Instead of tapped controller it send tabbarcontroller