### PR TITLE
RAMBadge public init

### DIFF
--- a/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
+++ b/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
@@ -37,7 +37,7 @@ extension RAMAnimatedTabBarItem {
             }
 
             if badge == nil {
-                badge = RAMBadge.bage()
+                badge = RAMBadge.badge()
                 if let contanerView = self.iconView!.icon.superview {
                     badge!.addBadgeOnView(contanerView)
                 }

--- a/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
+++ b/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
@@ -36,18 +36,15 @@ extension RAMAnimatedTabBarItem {
                 return
             }
 
-            if badge == nil {
+            if let iconView = iconView, let contanerView = iconView.icon.superview where badge == nil {
                 badge = RAMBadge.badge()
-                if let iconView = iconView, let contanerView = iconView.icon.superview {
-                    badge!.addBadgeOnView(contanerView)
-                }
+                badge!.addBadgeOnView(contanerView)
             }
 
             badge?.text = newValue
         }
     }
 }
-
 
 public class RAMAnimatedTabBarItem: UITabBarItem {
 

--- a/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
+++ b/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
@@ -38,7 +38,7 @@ extension RAMAnimatedTabBarItem {
 
             if badge == nil {
                 badge = RAMBadge.badge()
-                if let contanerView = self.iconView!.icon.superview {
+                if let iconView = iconView, let contanerView = iconView.icon.superview {
                     badge!.addBadgeOnView(contanerView)
                 }
             }

--- a/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
+++ b/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
@@ -69,7 +69,7 @@ public class RAMBadge: UILabel {
     
     // PRAGMA: helpers
     
-    internal func addBadgeOnView(onView:UIView) {
+    public func addBadgeOnView(onView:UIView) {
 
         onView.addSubview(self)
 

--- a/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
+++ b/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
@@ -12,21 +12,20 @@ public class RAMBadge: UILabel {
     
     var topConstraint: NSLayoutConstraint?
     var centerXConstraint: NSLayoutConstraint?
-    var numberLabel: UILabel?
-    
-    class func bage()->RAMBadge {
-        return RAMBadge.init(frame: CGRectMake(0, 0, 18, 18))
+
+    public class func badge() -> RAMBadge {
+        return RAMBadge.init(frame: CGRectMake(0, 0, 8, 8))
     }
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
         
-        self.layer.backgroundColor = UIColor.redColor().CGColor;
-        self.layer.cornerRadius = frame.size.width / 2;
+        layer.backgroundColor = UIColor.redColor().CGColor;
+        layer.cornerRadius = frame.size.width / 2;
         
-       configureNumberLabel()
+        configureNumberLabel()
 
-        self.translatesAutoresizingMaskIntoConstraints = false
+        translatesAutoresizingMaskIntoConstraints = false
         
         // constraints
         createSizeConstraints(frame.size)
@@ -39,7 +38,7 @@ public class RAMBadge: UILabel {
     
     // PRAGMA: create
     
-    func createSizeConstraints(size: CGSize) {
+    internal func createSizeConstraints(size: CGSize) {
         let widthConstraint = NSLayoutConstraint(
             item: self,
             attribute: NSLayoutAttribute.Width,
@@ -63,15 +62,14 @@ public class RAMBadge: UILabel {
     }
     
     func configureNumberLabel()  {
-        
-        self.textAlignment = .Center
-        self.font = UIFont.systemFontOfSize(13)
-        self.textColor = UIColor.whiteColor()
+        textAlignment = .Center
+        font = UIFont.systemFontOfSize(13)
+        textColor = UIColor.whiteColor()
     }
     
     // PRAGMA: helpers
     
-    func addBadgeOnView(onView:UIView) {
+    internal func addBadgeOnView(onView:UIView) {
 
         onView.addSubview(self)
 

--- a/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
+++ b/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
@@ -18,7 +18,7 @@ public class RAMBadge: UILabel {
         return RAMBadge.init(frame: CGRectMake(0, 0, 18, 18))
     }
     
-    override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         super.init(frame: frame)
         
         self.layer.backgroundColor = UIColor.redColor().CGColor;

--- a/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
+++ b/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
@@ -10,11 +10,11 @@ import UIKit
 
 public class RAMBadge: UILabel {
     
-    var topConstraint: NSLayoutConstraint?
-    var centerXConstraint: NSLayoutConstraint?
+    internal var topConstraint: NSLayoutConstraint?
+    internal var centerXConstraint: NSLayoutConstraint?
 
     public class func badge() -> RAMBadge {
-        return RAMBadge.init(frame: CGRectMake(0, 0, 8, 8))
+        return RAMBadge.init(frame: CGRectMake(0, 0, 18, 18))
     }
     
     override public init(frame: CGRect) {
@@ -61,7 +61,7 @@ public class RAMBadge: UILabel {
         self.addConstraint(heightConstraint)
     }
     
-    func configureNumberLabel()  {
+    private func configureNumberLabel()  {
         textAlignment = .Center
         font = UIFont.systemFontOfSize(13)
         textColor = UIColor.whiteColor()


### PR DESCRIPTION
## Scope

- [x] Public `init(frame:)` in order to overwrite `badge` appearance
- [x] Do not force unwrap `iconView`
- [x] Do not create instance of `RAMBadge` if `iconView` does not exist (Result will be `tabBarItem` will have instance of `RAMBadge` but will not be added as subview.)
- [x] Remove unused `numberLabel` `UILabel`

## Discussion

- Using `convenience init` instead of class func initialiser for `RAMBadge` (`RAMBadge.badge()` -> `RAMBadge()`)
