### PR TITLE
Improved RAMBadge for 2 or more digit badges

### DIFF
--- a/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
+++ b/RAMAnimatedTabBarController/RAMBadge/RAMBadge.swift
@@ -31,6 +31,12 @@ open class RAMBadge: UILabel {
         createSizeConstraints(frame.size)
 
     }
+    
+    override open var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.width += 10.0
+        return contentSize
+    }
 
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")


### PR DESCRIPTION
Added override of intrinsicContentSize variable to increase content size width value.
This change gives better look of badges with 2 or more digits. 

Before:

![223033755_10876885929580095997](https://cloud.githubusercontent.com/assets/7448756/20495302/2d145d54-b029-11e6-9a41-31520cd803df.jpg)

After changes:

![223023218_7161634234065382897](https://cloud.githubusercontent.com/assets/7448756/20495312/355f63c8-b029-11e6-97d2-3c70e6c24210.jpg)
