### PR TITLE
Prevent "multiple touch" on TabBar

### DIFF
--- a/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
+++ b/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
@@ -396,6 +396,7 @@ open class RAMAnimatedTabBarController: UITabBarController {
     let viewContainer = UIView();
     viewContainer.backgroundColor = UIColor.clear // for test
     viewContainer.translatesAutoresizingMaskIntoConstraints = false
+    viewContainer.isExclusiveTouch = true
     view.addSubview(viewContainer)
     
     // add gesture


### PR DESCRIPTION
Disabled "multiple touch" for TabBar items to prevent flickering on simultaneous touches.