### PR TITLE
[Doc] Fixed parameter name

### DIFF
--- a/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
+++ b/RAMAnimatedTabBarController/RAMAnimatedTabBarController.swift
@@ -234,7 +234,7 @@ open class RAMAnimatedTabBarController: UITabBarController {
   /**
    Returns a newly initialized view controller with the nib file in the specified bundle.
    
-   - parameter coder: An unarchiver object.
+   - parameter aDecoder: An unarchiver object.
    
    - returns: A newly initialized RAMAnimatedTabBarController object.
    */


### PR DESCRIPTION
Fixed parameter name in documentation. This caused Xcode to generate a warning in a project of mine using RAMAnimatedTabBarController.