### PR TITLE
fix warning 'M_PI is deprecated' in Swift 3.1

### DIFF
--- a/RAMAnimatedTabBarController/Animations/RotationAnimation/RAMRotationAnimation.swift
+++ b/RAMAnimatedTabBarController/Animations/RotationAnimation/RAMRotationAnimation.swift
@@ -91,7 +91,7 @@ open class RAMRotationAnimation : RAMItemAnimation {
     let rotateAnimation = CABasicAnimation(keyPath: Constants.AnimationKeys.Rotation)
     rotateAnimation.fromValue = 0.0
     
-    var toValue = CGFloat(M_PI * 2.0)
+    var toValue = CGFloat.pi * 2
     if direction != nil && direction == RAMRotationDirection.left {
       toValue = toValue * -1.0
     }


### PR DESCRIPTION
M_PI is deprecated in Swift 3.1